### PR TITLE
Use persistent HTTP connections

### DIFF
--- a/.gemspec
+++ b/.gemspec
@@ -29,6 +29,7 @@ Gem::Specification.new do |gem|
   gem.requirements               = []
   gem.add_runtime_dependency     'json_pure', '>= 1.4.2' # included in Ruby 1.9.2
   gem.add_runtime_dependency     'rdf',       '~> 0.3.0'
+  gem.add_runtime_dependency     'net-http-persistent',       '~> 1.4.1'
   gem.add_development_dependency 'yard' ,     '>= 0.6.0'
   gem.add_development_dependency 'rspec',     '>= 2.1.0'
   gem.add_development_dependency 'rdf-spec',  '~> 0.3.0'

--- a/lib/sparql/client.rb
+++ b/lib/sparql/client.rb
@@ -1,4 +1,4 @@
-require 'net/http'
+require 'net/http/persistent'
 require 'rdf' # @see http://rubygems.org/gems/rdf
 require 'rdf/ntriples'
 
@@ -33,6 +33,7 @@ module SPARQL
       @url, @options = RDF::URI.new(url.to_s), options
       #@headers = {'Accept' => "#{RESULT_JSON}, #{RESULT_XML}, text/plain"}
       @headers = {'Accept' => [RESULT_JSON, RESULT_XML, RDF::Format.content_types.collect { |k,v| k.to_s }].join(', ')}
+      @http = http_klass(@url.scheme)
 
       if block_given?
         case block.arity
@@ -259,11 +260,9 @@ module SPARQL
         when "https"
           proxy_uri = URI.parse(ENV['https_proxy']) unless ENV['https_proxy'].nil?
       end
-      return Net::HTTP if proxy_uri.nil? 
-
-      proxy_host, proxy_port = proxy_uri.host, proxy_uri.port
-      proxy_user, proxy_pass = proxy_uri.userinfo.split(/:/) if proxy_uri.userinfo
-      Net::HTTP::Proxy(proxy_host, proxy_port, proxy_user, proxy_pass)
+      klass = Net::HTTP::Persistent.new(self.class.to_s, proxy_uri)
+      klass.keep_alive = 120	# increase to 2 minutes
+      klass
     end
 
     ##
@@ -278,13 +277,12 @@ module SPARQL
       url = self.url.dup
       url.query_values = {:query => query.to_s}
 
-      http_klass(url.scheme).start(url.host, url.port) do |http|
-        response = http.get(url.path + "?#{url.query}", @headers.merge(headers))
-        if block_given?
-          block.call(response)
-        else
-          response
-        end
+      request = Net::HTTP::Get.new(url.request_uri, @headers.merge(headers))
+      response = @http.request url, request
+      if block_given?
+	block.call(response)
+      else
+	response
       end
     end
   end # Client


### PR DESCRIPTION
the old way of using http_klass.start() with a block caused sparql-client to open and close
a HTTP connection for each request.  All the resulting TCP 3-way handshakes are deadly
when acessing a repository in e.g. California from Germany.

Using Net::HTTP::Persistent helps a lot with that.  Unfortunately it does not have an API that
is a drop-in replacement with Net::HTTP, so I ended up with a one-or-the-other situation.

What do you think?
