### PR TITLE
Basic auth

### DIFF
--- a/lib/sparql/client.rb
+++ b/lib/sparql/client.rb
@@ -289,7 +289,7 @@ module SPARQL
       url.query_values = {:query => query.to_s}
 
       request = Net::HTTP::Get.new(url.request_uri, @headers.merge(headers))
-      request.basic_auth url.user, url.password if url.user && !url.empty?
+      request.basic_auth url.user, url.password if url.user && !url.user.empty?
       response = @http.request url, request
       if block_given?
 	block.call(response)


### PR DESCRIPTION
Simple addition to support basic auth if provided in the URL, e.g.

SPARQL::Client.new('http://user:pass@hostname.com/')

Needed for usage with some SPARQL endpoints. Do you have any interest in converting this over to use RestClient? I think it would clean up some of the HTTP code and features like basic auth would come along for free. I can make these changes if interested.
