### PR TITLE
add read_timeout support for requests

### DIFF
--- a/lib/sparql/client.rb
+++ b/lib/sparql/client.rb
@@ -64,6 +64,7 @@ module SPARQL
     # @option options [Symbol] :method (DEFAULT_METHOD)
     # @option options [Number] :protocol (DEFAULT_PROTOCOL)
     # @option options [Hash] :headers
+    # @option options [Hash] :read_timeout
     def initialize(url, options = {}, &block)
       case url
       when RDF::Queryable
@@ -540,6 +541,7 @@ module SPARQL
       end
       klass = Net::HTTP::Persistent.new(self.class.to_s, proxy_url)
       klass.keep_alive = 120 # increase to 2 minutes
+      klass.read_timeout = @options[:read_timeout] || 60
       klass
     end
 


### PR DESCRIPTION
Hello, i would like to be able to define the read_timeout in my code. I found this issue https://github.com/ruby-rdf/sparql-client/pull/33 .

I have copied the commit https://github.com/ncbo/sparql-client/commit/39149817eda009006ab030c3f8d58daaaec811ea comming from palexander.

Thanks for your work, chris
