### PR TITLE
Add a mechanism to override the HTTP verb

### DIFF
--- a/lib/sparql/client.rb
+++ b/lib/sparql/client.rb
@@ -659,8 +659,6 @@ module SPARQL
     # @return [Net::HTTPResponse]
     # @see    http://www.w3.org/TR/sparql11-protocol/#query-operation
     def request(query, headers = {}, &block)
-      method = (self.options[:method] || DEFAULT_METHOD).to_sym
-
       # Make sure an appropriate Accept header is present
       headers['Accept'] ||= if (query.respond_to?(:expects_statements?) ?
                                 query.expects_statements? :
@@ -670,7 +668,7 @@ module SPARQL
         RESULT_ALL
       end
 
-      request = send("make_#{method}_request", query, headers)
+      request = send("make_#{method(query)}_request", query, headers)
 
       request.basic_auth(url.user, url.password) if url.user && !url.user.empty?
 
@@ -685,6 +683,15 @@ module SPARQL
       end
       raise ServerError, "Infinite redirect at #{url}. Redirected more than 10 times."
     end
+
+    ##
+    # Return the HTTP verb for posting this request.
+    # this is useful if you need to override the HTTP verb based on the request being made.
+    # (e.g. Marmotta 3.3.0 requires GET for DELETE requests, but can accept POST for INSERT)
+    def method(query)
+      (options[:method] || DEFAULT_METHOD).to_sym
+    end
+
 
     ##
     # Constructs an HTTP GET request according to the SPARQL Protocol.

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -85,6 +85,14 @@ describe SPARQL::Client do
       client.query(query)
     end
 
+    it "should enable overriding the http method" do
+      stub_request(:get, "http://data.linkedmdb.org/sparql?query=DESCRIBE%20?kb%20WHERE%20%7B%20?kb%20%3Chttp://data.linkedmdb.org/resource/movie/actor_name%3E%20%22Kevin%20Bacon%22%20.%20%7D").
+         to_return(:status => 200, :body => "", :headers => {})
+      allow(subject).to receive(:method).with(query).and_return(:get)
+      expect(subject).to receive(:make_get_request).and_call_original
+      subject.query(query)
+    end
+
     it "should support international characters in response body" do
       client = SPARQL::Client.new('http://dbpedia.org/sparql')
       json = {


### PR DESCRIPTION
Marmotta 3.3.0 requires GET for DELETE requests, but can
accept POST for INSERT

This enables rdf-marmotta to override less of #request. See
https://github.com/dpla/rdf-marmotta/pull/8