### PR TITLE
Added support for specifying the sort order in SPARQL::Client::Query.order()

### DIFF
--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -120,11 +120,23 @@ describe SPARQL::Client::Query do
 
     it "should support ORDER BY" do
       expect(subject.select.where([:s, :p, :o]).order_by(:o).to_s).to eq "SELECT * WHERE { ?s ?p ?o . } ORDER BY ?o"
+      expect(subject.select.where([:s, :p, :o]).order_by(:o, :p).to_s).to eq "SELECT * WHERE { ?s ?p ?o . } ORDER BY ?o ?p"
       expect(subject.select.where([:s, :p, :o]).order_by('?o').to_s).to eq "SELECT * WHERE { ?s ?p ?o . } ORDER BY ?o"
-      #expect(subject.select.where([:s, :p, :o]).order_by(:o => :asc).to_s).to eq "SELECT * WHERE { ?s ?p ?o . } ORDER BY ?o ASC"
-      expect(subject.select.where([:s, :p, :o]).order_by('?o ASC').to_s).to eq "SELECT * WHERE { ?s ?p ?o . } ORDER BY ?o ASC"
-      # expect(subject.select.where([:s, :p, :o]).order_by(:o => :desc).to_s.to) eq "SELECT * WHERE { ?s ?p ?o . } ORDER BY ?o DESC"
-      expect(subject.select.where([:s, :p, :o]).order_by('?o DESC').to_s).to eq "SELECT * WHERE { ?s ?p ?o . } ORDER BY ?o DESC"
+      expect(subject.select.where([:s, :p, :o]).order_by('ASC(?o)').to_s).to eq "SELECT * WHERE { ?s ?p ?o . } ORDER BY ASC(?o)"
+      expect(subject.select.where([:s, :p, :o]).order_by('DESC(?o)').to_s).to eq "SELECT * WHERE { ?s ?p ?o . } ORDER BY DESC(?o)"
+      expect(subject.select.where([:s, :p, :o]).order_by(:o => :asc).to_s).to eq "SELECT * WHERE { ?s ?p ?o . } ORDER BY ASC(?o)"
+      expect(subject.select.where([:s, :p, :o]).order_by(:o => :desc).to_s).to eq "SELECT * WHERE { ?s ?p ?o . } ORDER BY DESC(?o)"
+      expect(subject.select.where([:s, :p, :o]).order_by(:o => :asc, :p => :desc).to_s).to eq "SELECT * WHERE { ?s ?p ?o . } ORDER BY ASC(?o) DESC(?p)"
+      expect(subject.select.where([:s, :p, :o]).order_by([:o, :asc]).to_s).to eq "SELECT * WHERE { ?s ?p ?o . } ORDER BY ASC(?o)"
+      expect(subject.select.where([:s, :p, :o]).order_by([:o, :desc]).to_s).to eq "SELECT * WHERE { ?s ?p ?o . } ORDER BY DESC(?o)"
+      expect(subject.select.where([:s, :p, :o]).order_by([:o, :asc], [:p, :desc]).to_s).to eq "SELECT * WHERE { ?s ?p ?o . } ORDER BY ASC(?o) DESC(?p)"
+      expect { subject.select.where([:s, :p, :o]).order_by(42).to_s }.to raise_error(ArgumentError)
+      expect { subject.select.where([:s, :p, :o]).order_by(:o, 42).to_s }.to raise_error(ArgumentError)
+      expect { subject.select.where([:s, :p, :o]).order_by([:o]).to_s }.to raise_error(ArgumentError)
+      expect { subject.select.where([:s, :p, :o]).order_by([:o, :csa]).to_s }.to raise_error(ArgumentError)
+      expect { subject.select.where([:s, :p, :o]).order_by([:o, :asc, 42]).to_s }.to raise_error(ArgumentError)
+      expect { subject.select.where([:s, :p, :o]).order_by(:o => 42).to_s }.to raise_error(ArgumentError)
+      expect { subject.select.where([:s, :p, :o]).order_by(42 => :asc).to_s }.to raise_error(ArgumentError)
     end
 
     it "should support OFFSET" do


### PR DESCRIPTION
Hi,

based on a short discussion (issue #60) -- I added support for specifying the sort order direction with `sparql-client`'s query DSL ::
* `query.order(:var1 => :asc, :var2 => :desc)`
* `query.order([:var1, :asc], [:var2, :desc])`    

Both -- Arrays and Hashes are supported as arguments. If not both should be supported, I will remove one of them.

Cheers,
Chris