### PR TITLE
raise error when no suitable rdf reader is found

### DIFF
--- a/lib/sparql/client.rb
+++ b/lib/sparql/client.rb
@@ -539,6 +539,8 @@ module SPARQL
       options = {:content_type => response.content_type} if options.empty?
       if reader = RDF::Reader.for(options)
         reader.new(response.body)
+      else
+        raise ArgumentError, "no suitable rdf reader was found."
       end
     end
 

--- a/lib/sparql/client.rb
+++ b/lib/sparql/client.rb
@@ -540,7 +540,7 @@ module SPARQL
       if reader = RDF::Reader.for(options)
         reader.new(response.body)
       else
-        raise ArgumentError, "no suitable rdf reader was found."
+        raise RDF::ReaderError, "no suitable rdf reader was found."
       end
     end
 

--- a/lib/sparql/client.rb
+++ b/lib/sparql/client.rb
@@ -536,7 +536,7 @@ module SPARQL
     # @param  [Hash{Symbol => Object}] options
     # @return [RDF::Enumerable]
     def parse_rdf_serialization(response, options = {})
-      options = {:content_type => response.content_type} if options.empty?
+      options = {:content_type => response.content_type} unless options[:content_type]
       if reader = RDF::Reader.for(options)
         reader.new(response.body)
       else

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -55,7 +55,7 @@ describe SPARQL::Client do
 
     it "should handle successful response with plain header" do
       expect(subject).to receive(:request).and_yield response('text/plain')
-      expect(RDF::Reader).to receive(:for).with(:content_type => 'text/plain')
+      expect(RDF::Reader).to receive(:for).with(:content_type => 'text/plain').and_return RDF::Reader.for(content_type: 'text/plain')
       subject.query(query)
     end
 
@@ -117,6 +117,7 @@ describe SPARQL::Client do
       client = SPARQL::Client.new('http://data.linkedmdb.org/sparql', options)
       client.instance_variable_set :@http, double(:request => response('text/plain'))
       expect(Net::HTTP::Get).to receive(:new).with(anything, hash_including(options[:headers]))
+      expect(RDF::Reader).to receive(:for).and_return(RDF::Reader.for(:content_type => 'text/plain'))
       client.query(query)
     end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -123,7 +123,7 @@ describe SPARQL::Client do
 
     it "should enable overriding the http method" do
       stub_request(:get, "http://data.linkedmdb.org/sparql?query=DESCRIBE%20?kb%20WHERE%20%7B%20?kb%20%3Chttp://data.linkedmdb.org/resource/movie/actor_name%3E%20%22Kevin%20Bacon%22%20.%20%7D").
-         to_return(:status => 200, :body => "", :headers => {})
+         to_return(:status => 200, :body => "", :headers => { 'Content-Type' => 'application/n-triples'})
       allow(subject).to receive(:request_method).with(query).and_return(:get)
       expect(subject).to receive(:make_get_request).and_call_original
       subject.query(query)
@@ -153,7 +153,8 @@ describe SPARQL::Client do
 
       it 'follows redirects' do
         WebMock.stub_request(:any, 'http://sparql.linkedmdb.org/sparql').
-          to_return(:body => '{}', :status => 200)
+          to_return(:body => '{}', :status => 200, :headers => { 'Content-Type' => SPARQL::Client::RESULT_JSON})
+
         subject.query(ask_query)
         expect(WebMock).to have_requested(:post, "http://sparql.linkedmdb.org/sparql").
           with(:body => 'query=ASK+WHERE+%7B+%3Fkb+%3Chttp%3A%2F%2Fdata.linkedmdb.org%2Fresource%2Fmovie%2Factor_name%3E+%22Kevin+Bacon%22+.+%7D')


### PR DESCRIPTION
Currently sparql-client will silently fail with a nil if no suitable rdf reader is found. This can lead to the awkward situation where a nil is returned for the query and the user has to find out what is causing it. This pull request tries to quicken this debugging proces by at least indicating the point of failure by raising a descriptive error.
```
[1] pry(main)> require 'sparql/client'
=> true
[2] pry(main)> s = SPARQL::Client.new('http://localhost:8890/sparql')
=> #<SPARQL::Client:0x8fc(http://localhost:8890/sparql)>
[3] pry(main)> s.query("CONSTRUCT  {?s a ?type}  WHERE {?s a ?type}").first
NoMethodError: undefined method `first' for nil:NilClass
from (pry):3:in `<eval>'
[4] pry(main)> require 'rdf/turtle'
=> true
[5] pry(main)> s = SPARQL::Client.new('http://localhost:8890/sparql')
=> #<SPARQL::Client:0x902(http://localhost:8890/sparql)>
[6] pry(main)> s.query("CONSTRUCT  {?s a ?type}  WHERE {?s a ?type}").first
=> [#<RDF::URI:0x906 URI:http://www.openlinksw.com/virtrdf-data-formats#default-iid>, #<RDF::URI:0x908 URI:http://www.w3.org/1999/02/22-rdf-syntax-ns#type>, #<RDF::URI:0x90a URI:http://www.openlinksw.com/schemas/virtrdf#QuadMapFormat>]
```