### PR TITLE
content_type should always be passed to RDF::Reader.for

### DIFF
--- a/lib/sparql/client.rb
+++ b/lib/sparql/client.rb
@@ -536,7 +536,7 @@ module SPARQL
     # @param  [Hash{Symbol => Object}] options
     # @return [RDF::Enumerable]
     def parse_rdf_serialization(response, options = {})
-      options = {:content_type => response.content_type} if options.empty?
+      options = {:content_type => response.content_type} unless options[:content_type]
       if reader = RDF::Reader.for(options)
         reader.new(response.body)
       end


### PR DESCRIPTION
currently content_type is not passed to Rdf::Reader.for() if options is set and options does not contain content_type. This causes a failure to load the correct Rdf::Reader.

This PR addresses that by passing `{content_type: response.content_type}` if options.content_type is not set