### PR TITLE
raise error when no suitable rdf reader is found

### DIFF
--- a/lib/sparql/client.rb
+++ b/lib/sparql/client.rb
@@ -539,6 +539,8 @@ module SPARQL
       options = {:content_type => response.content_type} unless options[:content_type]
       if reader = RDF::Reader.for(options)
         reader.new(response.body)
+      else
+        raise RDF::ReaderError, "no suitable rdf reader was found."
       end
     end
 

--- a/lib/sparql/client.rb
+++ b/lib/sparql/client.rb
@@ -536,7 +536,7 @@ module SPARQL
     # @param  [Hash{Symbol => Object}] options
     # @return [RDF::Enumerable]
     def parse_rdf_serialization(response, options = {})
-      options = {:content_type => response.content_type} if options.empty?
+      options = {:content_type => response.content_type} unless options[:content_type]
       if reader = RDF::Reader.for(options)
         reader.new(response.body)
       end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -122,7 +122,7 @@ describe SPARQL::Client do
 
     it "should enable overriding the http method" do
       stub_request(:get, "http://data.linkedmdb.org/sparql?query=DESCRIBE%20?kb%20WHERE%20%7B%20?kb%20%3Chttp://data.linkedmdb.org/resource/movie/actor_name%3E%20%22Kevin%20Bacon%22%20.%20%7D").
-         to_return(:status => 200, :body => "", :headers => {})
+         to_return(:status => 200, :body => "", :headers => { 'Content-Type' => 'application/n-triples'})
       allow(subject).to receive(:request_method).with(query).and_return(:get)
       expect(subject).to receive(:make_get_request).and_call_original
       subject.query(query)
@@ -152,7 +152,7 @@ describe SPARQL::Client do
 
       it 'follows redirects' do
         WebMock.stub_request(:any, 'http://sparql.linkedmdb.org/sparql').
-          to_return(:body => '{}', :status => 200)
+          to_return(:body => '{}', :status => 200, :headers => { :content_type => SPARQL::Client::RESULT_JSON})
         subject.query(ask_query)
         expect(WebMock).to have_requested(:post, "http://sparql.linkedmdb.org/sparql").
           with(:body => 'query=ASK+WHERE+%7B+%3Fkb+%3Chttp%3A%2F%2Fdata.linkedmdb.org%2Fresource%2Fmovie%2Factor_name%3E+%22Kevin+Bacon%22+.+%7D')

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -55,7 +55,7 @@ describe SPARQL::Client do
 
     it "should handle successful response with plain header" do
       expect(subject).to receive(:request).and_yield response('text/plain')
-      expect(RDF::Reader).to receive(:for).with(:content_type => 'text/plain')
+      expect(RDF::Reader).to receive(:for).with(:content_type => 'text/plain').and_call_original
       subject.query(query)
     end
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -2,6 +2,7 @@
 require File.join(File.dirname(__FILE__), 'spec_helper')
 require 'webmock/rspec'
 require 'json'
+require 'rdf/turtle'
 
 describe SPARQL::Client do
   let(:query) {'DESCRIBE ?kb WHERE { ?kb <http://data.linkedmdb.org/resource/movie/actor_name> "Kevin Bacon" . }'}
@@ -102,7 +103,7 @@ describe SPARQL::Client do
 
     it "should handle successful response with overridden plain header" do
       expect(subject).to receive(:request).and_yield response('text/plain')
-      expect(RDF::Reader).to receive(:for).with(:content_type => 'text/turtle')
+      expect(RDF::Reader).to receive(:for).with(:content_type => 'text/turtle').and_call_original
       subject.query(query, :content_type => 'text/turtle')
     end
 


### PR DESCRIPTION
Currently sparql-client will silently fail with a nil if no suitable rdf reader is found. This can lead to the awkward situation where a nil is returned for the query and the user has to find out what is causing it. This pull request tries to quicken this debugging proces by at least indicating the point of failure by raising a descriptive error.
```
[1] pry(main)> require 'sparql/client'
=> true
[2] pry(main)> s = SPARQL::Client.new('http://localhost:8890/sparql')
=> #<SPARQL::Client:0x8fc(http://localhost:8890/sparql)>
[3] pry(main)> s.query("CONSTRUCT  {?s a ?type}  WHERE {?s a ?type}").first
NoMethodError: undefined method `first' for nil:NilClass
from (pry):3:in `<eval>'
[4] pry(main)> require 'rdf/turtle'
=> true
[5] pry(main)> s = SPARQL::Client.new('http://localhost:8890/sparql')
=> #<SPARQL::Client:0x902(http://localhost:8890/sparql)>
[6] pry(main)> s.query("CONSTRUCT  {?s a ?type}  WHERE {?s a ?type}").first
=> [#<RDF::URI:0x906 URI:http://www.openlinksw.com/virtrdf-data-formats#default-iid>, #<RDF::URI:0x908 URI:http://www.w3.org/1999/02/22-rdf-syntax-ns#type>, #<RDF::URI:0x90a URI:http://www.openlinksw.com/schemas/virtrdf#QuadMapFormat>]
```

This pull request replaces #66 and should be merged after #67.