### PR TITLE
Fix for issues with the alternative endpoint override

### DIFF
--- a/lib/sparql/client.rb
+++ b/lib/sparql/client.rb
@@ -291,6 +291,7 @@ module SPARQL
     # @see    http://www.w3.org/TR/sparql11-protocol/#query-operation
     def query(query, options = {})
       @op = :query
+      @alt_endpoint = options[:endpoint]
       case @url
       when RDF::Queryable
         require 'sparql' unless defined?(::SPARQL::Grammar)
@@ -317,7 +318,7 @@ module SPARQL
     # @see    http://www.w3.org/TR/sparql11-protocol/#update-operation
     def update(query, options = {})
       @op = :update
-      @alt_endpoint = options[:endpoint] unless options[:endpoint].nil?
+      @alt_endpoint = options[:endpoint]
       case @url
       when RDF::Queryable
         require 'sparql' unless defined?(::SPARQL::Grammar)


### PR DESCRIPTION
The alternative endpoint is set optionally in the update method if an
endpoint is provided in the options. If the next call doesn't provide an
alternative endpoint, it should use the instance's configured endpoint.

Also: a call to the query method may use the make_post_request method.
We should make sure to not keep any previous alternative endpoint.

Note: this commit not only fix the current issues with the alternative
endpoints, it also implements a new functionality: the possibility to
override the configured endpoint when calling the query method.