### PR TITLE
Improvement: don't parse update response

### DIFF
--- a/lib/sparql/client.rb
+++ b/lib/sparql/client.rb
@@ -323,7 +323,7 @@ module SPARQL
         require 'sparql' unless defined?(::SPARQL::Grammar)
         SPARQL.execute(query, @url, options.merge(update: true))
       else
-        parse_response(response(query, options), options)
+        response(query, options)
       end
       self
     end


### PR DESCRIPTION
The result of an update is not accessible to the caller. Therefore,
there is no point of parsing it and it's a risk that the whole call
fails if an error occurs during the parsing.

Fixes #71 