### PR TITLE
Improved error message

### DIFF
--- a/lib/sparql/client.rb
+++ b/lib/sparql/client.rb
@@ -543,7 +543,7 @@ module SPARQL
       if reader = RDF::Reader.for(options)
         reader.new(response.body)
       else
-        raise RDF::ReaderError, "no suitable rdf reader was found."
+        raise RDF::ReaderError, "no RDF reader was found for #{options}."
       end
     end
 


### PR DESCRIPTION
I ran into this exception today and thought it would be nice to have the actual options (such as the `content_type`) displayed in the error message.