### PR TITLE
Prefix uri multi arg support closes #89

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ doc
 coverage
 .bundle
 /.byebug_history
+.ruby-version

--- a/lib/sparql/client/query.rb
+++ b/lib/sparql/client/query.rb
@@ -1,4 +1,4 @@
-module SPARQL; class Client
+class SPARQL::Client
   ##
   # A SPARQL query builder.
   #
@@ -366,16 +366,36 @@ module SPARQL; class Client
     end
 
     ##
-    # @example PREFIX dc: <http://purl.org/dc/elements/1.1/> PREFIX foaf: <http://xmlns.com/foaf/0.1/> SELECT * WHERE \{ ?s ?p ?o . \}
-    #   query.select.
-    #     prefix(dc: RDF::URI("http://purl.org/dc/elements/1.1/")).
-    #     prefix(foaf: RDF::URI("http://xmlns.com/foaf/0.1/")).
-    #     where([:s, :p, :o])
+    # @overload prefix(prefix: uri)
+    #   @example PREFIX dc: <http://purl.org/dc/elements/1.1/> PREFIX foaf: <http://xmlns.com/foaf/0.1/> SELECT * WHERE \{ ?s ?p ?o . \}
+    #     query.select.
+    #       prefix(dc: RDF::URI("http://purl.org/dc/elements/1.1/")).
+    #       prefix(foaf: RDF::URI("http://xmlns.com/foaf/0.1/")).
+    #       where([:s, :p, :o])
     #
-    # @return [Query]
+    #   @param [RDF::URI] uri
+    #   @param [Symbol, String] prefix
+    #   @return [Query]
+    #
+    # @overload prefix(string)
+    #   @example PREFIX dc: <http://purl.org/dc/elements/1.1/> PREFIX foaf: <http://xmlns.com/foaf/0.1/> SELECT * WHERE \{ ?s ?p ?o . \}
+    #     query.select.
+    #       prefix("dc: <http://purl.org/dc/elements/1.1/>").
+    #       prefix("foaf: <http://xmlns.com/foaf/0.1/>").
+    #       where([:s, :p, :o])
+    #
+    #   @param [string] string
+    #   @return [Query]
     # @see    http://www.w3.org/TR/sparql11-query/#prefNames
-    def prefix(string)
-      (options[:prefixes] ||= []) << string
+    def prefix(*args)
+      case args.length
+      when 1
+        (options[:prefixes] ||= []) << args[0]
+      when 2
+        (options[:prefixes] ||= []) << "#{args[0]}: <#{args[1]}>"
+      else
+        raise ArgumentError, "wrong number of arguments (#{args.length} for 1 or 2)"
+      end
       self
     end
 
@@ -823,4 +843,4 @@ module SPARQL; class Client
       end
     end
   end
-end; end
+end

--- a/lib/sparql/client/query.rb
+++ b/lib/sparql/client/query.rb
@@ -369,8 +369,8 @@ class SPARQL::Client
     # @overload prefix(prefix: uri)
     #   @example PREFIX dc: <http://purl.org/dc/elements/1.1/> PREFIX foaf: <http://xmlns.com/foaf/0.1/> SELECT * WHERE \{ ?s ?p ?o . \}
     #     query.select.
-    #       prefix(dc: RDF::URI("http://purl.org/dc/elements/1.1/")).
-    #       prefix(foaf: RDF::URI("http://xmlns.com/foaf/0.1/")).
+    #       prefix(:dc, RDF::URI("http://purl.org/dc/elements/1.1/")).
+    #       prefix(:foaf, RDF::URI("http://xmlns.com/foaf/0.1/")).
     #       where([:s, :p, :o])
     #
     #   @param [RDF::URI] uri

--- a/lib/sparql/client/repository.rb
+++ b/lib/sparql/client/repository.rb
@@ -1,4 +1,4 @@
-module SPARQL; class Client
+class SPARQL::Client
   ##
   # A read-only repository view of a SPARQL endpoint.
   #
@@ -345,4 +345,4 @@ module SPARQL; class Client
     end
 
   end
-end; end
+end

--- a/lib/sparql/client/version.rb
+++ b/lib/sparql/client/version.rb
@@ -1,4 +1,4 @@
-module SPARQL; class Client
+class SPARQL::Client
   module VERSION
     FILE = File.expand_path('../../../../VERSION', __FILE__)
     MAJOR, MINOR, TINY, EXTRA = File.read(FILE).chomp.split('.')
@@ -16,4 +16,4 @@ module SPARQL; class Client
     # @return [Array(Integer, Integer, Integer)]
     def self.to_a() [MAJOR, MINOR, TINY] end
   end
-end; end
+end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -182,27 +182,14 @@ describe SPARQL::Client::Query do
       expect(subject.select.where([:s, :p, :o]).slice(100, 10).to_s).to eq "SELECT * WHERE { ?s ?p ?o . } OFFSET 100 LIMIT 10"
     end
 
-    context 'when building PREFIX queries' do
-      before do
-        @string_prefixes = [
-          "dc: <http://purl.org/dc/elements/1.1/>", 
-          "foaf: <http://xmlns.com/foaf/0.1/>"
-        ]
-        @rdf_uri_prefixes = [
-          [:dc, RDF::URI("http://purl.org/dc/elements/1.1/")], 
-          [:foaf, RDF::URI("http://xmlns.com/foaf/0.1/")]
-        ]
-        # string and rdf_uri prefixes should be equivalent
-        # e.g. prefix("dc: <http://purl.org/dc/elements/1.1/>")
-        # prefix(:dc, RDF::URI('http://purl.org/dc/elements/1.1/'))
-        @expected_prefix_query = "PREFIX #{@string_prefixes[0]} PREFIX #{@string_prefixes[1]} SELECT * WHERE { ?s ?p ?o . }"
-      end
-      it "should support string PREFIX" do
-        expect(subject.select.prefix(@string_prefixes[0]).prefix(@string_prefixes[1]).where([:s, :p, :o]).to_s).to eq @expected_prefix_query
-      end
-      it "should support RDF::URI PREFIX" do
-        expect(subject.select.prefix(*@rdf_uri_prefixes[0]).prefix(*@rdf_uri_prefixes[1]).where([:s, :p, :o]).to_s).to eq @expected_prefix_query
-      end
+    it "should support string PREFIX" do
+      prefixes = ["dc: <http://purl.org/dc/elements/1.1/>", "foaf: <http://xmlns.com/foaf/0.1/>"]
+      expect(subject.select.prefix(prefixes[0]).prefix(prefixes[1]).where([:s, :p, :o]).to_s).to eq "PREFIX dc: <http://purl.org/dc/elements/1.1/> PREFIX foaf: <http://xmlns.com/foaf/0.1/> SELECT * WHERE { ?s ?p ?o . }"
+    end
+
+    it "should support RDF::URI PREFIX" do
+      prefixes = [[:dc, RDF::URI("http://purl.org/dc/elements/1.1/")], [:foaf, RDF::URI("http://xmlns.com/foaf/0.1/")]]
+      expect(subject.select.prefix(*prefixes[0]).prefix(*prefixes[1]).where([:s, :p, :o]).to_s).to eq "PREFIX dc: <http://purl.org/dc/elements/1.1/> PREFIX foaf: <http://xmlns.com/foaf/0.1/> SELECT * WHERE { ?s ?p ?o . }"
     end
 
     it "should support OPTIONAL" do

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -192,6 +192,13 @@ describe SPARQL::Client::Query do
       expect(subject.select.prefix(*prefixes[0]).prefix(*prefixes[1]).where([:s, :p, :o]).to_s).to eq "PREFIX dc: <http://purl.org/dc/elements/1.1/> PREFIX foaf: <http://xmlns.com/foaf/0.1/> SELECT * WHERE { ?s ?p ?o . }"
     end
 
+    it "should raise an ArgumentError for incorrect numbers arguments" do
+      prefixes = [[],Array.new(3, 'test')]
+      prefixes.each do |args|
+        expect { subject.select.prefix(*args) }.to raise_error ArgumentError, "wrong number of arguments (#{args.length} for 1 or 2)"
+      end
+    end
+
     it "should support OPTIONAL" do
       expect(subject.select.where([:s, :p, :o]).optional([:s, RDF.type, :o], [:s, RDF::URI("http://purl.org/dc/terms/abstract"), :o]).to_s).to eq "SELECT * WHERE { ?s ?p ?o . OPTIONAL { ?s a ?o . ?s <http://purl.org/dc/terms/abstract> ?o . } }"
     end

--- a/spec/query_spec.rb
+++ b/spec/query_spec.rb
@@ -182,9 +182,27 @@ describe SPARQL::Client::Query do
       expect(subject.select.where([:s, :p, :o]).slice(100, 10).to_s).to eq "SELECT * WHERE { ?s ?p ?o . } OFFSET 100 LIMIT 10"
     end
 
-    it "should support PREFIX" do
-      prefixes = ["dc: <http://purl.org/dc/elements/1.1/>", "foaf: <http://xmlns.com/foaf/0.1/>"]
-      expect(subject.select.prefix(prefixes[0]).prefix(prefixes[1]).where([:s, :p, :o]).to_s).to eq "PREFIX #{prefixes[0]} PREFIX #{prefixes[1]} SELECT * WHERE { ?s ?p ?o . }"
+    context 'when building PREFIX queries' do
+      before do
+        @string_prefixes = [
+          "dc: <http://purl.org/dc/elements/1.1/>", 
+          "foaf: <http://xmlns.com/foaf/0.1/>"
+        ]
+        @rdf_uri_prefixes = [
+          [:dc, RDF::URI("http://purl.org/dc/elements/1.1/")], 
+          [:foaf, RDF::URI("http://xmlns.com/foaf/0.1/")]
+        ]
+        # string and rdf_uri prefixes should be equivalent
+        # e.g. prefix("dc: <http://purl.org/dc/elements/1.1/>")
+        # prefix(:dc, RDF::URI('http://purl.org/dc/elements/1.1/'))
+        @expected_prefix_query = "PREFIX #{@string_prefixes[0]} PREFIX #{@string_prefixes[1]} SELECT * WHERE { ?s ?p ?o . }"
+      end
+      it "should support string PREFIX" do
+        expect(subject.select.prefix(@string_prefixes[0]).prefix(@string_prefixes[1]).where([:s, :p, :o]).to_s).to eq @expected_prefix_query
+      end
+      it "should support RDF::URI PREFIX" do
+        expect(subject.select.prefix(*@rdf_uri_prefixes[0]).prefix(*@rdf_uri_prefixes[1]).where([:s, :p, :o]).to_s).to eq @expected_prefix_query
+      end
     end
 
     it "should support OPTIONAL" do


### PR DESCRIPTION
Support for `prefix(:sym, RDF::URI)`
Following https://github.com/ruby-rdf/sparql-client/issues/89#issuecomment-437975172 format with args reversed as mentioned in https://github.com/ruby-rdf/sparql-client/issues/89#issuecomment-438189592