### PR TITLE
Feature/fix graph option documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ sparql = SPARQL::Client.new("http://dbpedia.org/sparql", headers: {'User-Agent' 
 
 ```ruby
 require 'sparql/client'
-sparql = SPARQL::Client.new("http://dbpedia.org/sparql", { graph: "http://dbpedia.org" })
+sparql = SPARQL::Client.new("http://dbpedia.org/sparql", graph: "http://dbpedia.org")
 ```
 
 

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -146,7 +146,7 @@ describe SPARQL::Client do
       expect(result[:name].to_s).to eq "東京"
     end
 
-    it "handles successful response with default graph specified", :focus => true do
+    it "handles successful response with default graph specified" do
       client = SPARQL::Client.new('http://dbpedia.org/sparql', graph: "https://example.org/")
       client.query(query)
     end

--- a/spec/client_spec.rb
+++ b/spec/client_spec.rb
@@ -146,6 +146,11 @@ describe SPARQL::Client do
       expect(result[:name].to_s).to eq "東京"
     end
 
+    it "handles successful response with default graph specified", :focus => true do
+      client = SPARQL::Client.new('http://dbpedia.org/sparql', graph: "https://example.org/")
+      client.query(query)
+    end
+
     it "generates IOError when querying closed client" do
       subject.close
       expect{ subject.query(ask_query) }.to raise_error IOError


### PR DESCRIPTION
Since cc9812c the interface to specify options has changed for the `SPARQL::Client`. I have reflected this change in the README and also have written a very stupid test. Unfortunately I don't know much about ruby test, so I was not able to write a test that checks that the `default-graph-uri` parameter is actually set.